### PR TITLE
Implement ResultsAnalyzer for deduplicating search results

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 requests
 beautifulsoup4
+
+pandas
+rapidfuzz

--- a/search_engines/__init__.py
+++ b/search_engines/__init__.py
@@ -1,4 +1,5 @@
 from .engines import *
+from .results_analyzer import ResultsAnalyzer
 
 
 __title__ = 'search_engines'
@@ -16,5 +17,6 @@ __all__ = [
     'Ask', 
     'Mojeek', 
     'Qwant',
-    'Torch'
+    'Torch',
+    'ResultsAnalyzer'
 ]

--- a/search_engines/results_analyzer.py
+++ b/search_engines/results_analyzer.py
@@ -1,0 +1,98 @@
+import json
+from collections import defaultdict
+from typing import List, Dict, Any
+from urllib.parse import urlparse, urlunparse
+
+from rapidfuzz import fuzz
+import pandas as pd
+
+
+class ResultsAnalyzer:
+    """Analyze and deduplicate search results from multiple strategies."""
+
+    def __init__(self) -> None:
+        """Initialize analyzer with tracking for URLs, domains, and quality metrics."""
+        self.seen_urls = set()
+        self.seen_domain_paths = {}
+
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        """Return URL without query parameters for deduplication."""
+        parsed = urlparse(url)
+        return urlunparse((parsed.scheme, parsed.netloc, parsed.path, '', '', ''))
+
+    @staticmethod
+    def _quality_score(result: Dict[str, Any]) -> float:
+        """Compute a rough quality score based on description length, page rank and redirects."""
+        description = result.get('description') or result.get('text') or ''
+        page = int(result.get('page', result.get('page_found', 1)))
+        url = result.get('url') or result.get('link', '')
+        score = len(description)
+        score += max(0, 50 - (page - 1) * 5)
+        if 'bing.com' in url and 'http' in urlparse(url).netloc:
+            score -= 5
+        return score
+
+    def _select_preferred(self, existing: Dict[str, Any], new: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the result with the higher quality score."""
+        return new if self._quality_score(new) > self._quality_score(existing) else existing
+
+    def deduplicate_results(self, results_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Remove duplicates and sort results by quality."""
+        deduped: List[Dict[str, Any]] = []
+        titles = []
+        for result in results_list:
+            url = result.get('url') or result.get('link')
+            if not url:
+                continue
+            if url in self.seen_urls:
+                continue
+            domain_path = self._normalize_url(url)
+            fuzzy_match = None
+            for t in titles:
+                if fuzz.ratio(t.lower(), (result.get('title') or '').lower()) > 90:
+                    fuzzy_match = t
+                    break
+            if fuzzy_match:
+                idx = titles.index(fuzzy_match)
+                deduped[idx] = self._select_preferred(deduped[idx], result)
+                self.seen_urls.add(url)
+                continue
+            if domain_path in self.seen_domain_paths:
+                idx = self.seen_domain_paths[domain_path]
+                deduped[idx] = self._select_preferred(deduped[idx], result)
+                self.seen_urls.add(url)
+                continue
+            self.seen_urls.add(url)
+            self.seen_domain_paths[domain_path] = len(deduped)
+            titles.append(result.get('title', ''))
+            deduped.append(result)
+        deduped.sort(key=self._quality_score, reverse=True)
+        return deduped
+
+    def analyze_coverage(self, results_by_strategy: Dict[str, List[Dict[str, Any]]], output_path: str = 'analysis_report.json') -> Dict[str, Any]:
+        """Analyze which search strategies found the most unique results."""
+        strategy_counts = {}
+        all_urls = set()
+        domain_counts = defaultdict(int)
+
+        for strategy, results in results_by_strategy.items():
+            urls = {r.get('url') or r.get('link') for r in results if r.get('url') or r.get('link')}
+            strategy_counts[strategy] = len(urls)
+            all_urls.update(urls)
+            for url in urls:
+                domain_counts[urlparse(url).netloc] += 1
+
+        ranking = sorted(strategy_counts.items(), key=lambda x: x[1], reverse=True)
+        recommended = [s for s, _ in ranking[:2]] if len(ranking) >= 2 else [s for s, _ in ranking]
+
+        analysis = {
+            'unique_urls_per_strategy': strategy_counts,
+            'strategy_ranking': ranking,
+            'domain_distribution': dict(sorted(domain_counts.items(), key=lambda x: x[1], reverse=True)),
+            'recommended_strategies': recommended,
+        }
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(analysis, f, indent=2)
+        return analysis

--- a/test_failed_strategies.py
+++ b/test_failed_strategies.py
@@ -13,7 +13,7 @@ except ImportError as e:
     print(f"Error importing search_engines: {e}")
     exit(1)
 
-def test_search_strategy(query, strategy_num, max_pages=5):
+def run_search_strategy(query, strategy_num, max_pages=5):
     """Test a single search strategy"""
     print(f"\n=== Strategy {strategy_num}: Testing '{query}' ===")
     
@@ -106,7 +106,7 @@ def main():
     csv_files = []
     
     for strategy_num, query in failed_strategies:
-        found, csv_file = test_search_strategy(query, strategy_num, max_pages=10)
+        found, csv_file = run_search_strategy(query, strategy_num, max_pages=10)
         total_found += found
         if found > 0:
             csv_files.append(csv_file)


### PR DESCRIPTION
## Summary
- add `ResultsAnalyzer` utility to deduplicate and rank search results
- expose the analyzer class from the `search_engines` package
- install pandas and rapidfuzz in requirements
- fix `test_failed_strategies.py` so pytest does not treat it as a test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407fe329ec8323975dce000e30102e